### PR TITLE
Remove span tag

### DIFF
--- a/src/LocPresentational.js
+++ b/src/LocPresentational.js
@@ -2,9 +2,7 @@ import translate from 'translatr'
 import React from 'react'
 
 const Loc = ({ currentLanguage, locKey, number, dictionary }) => {
-    return <span>
-        { translate( dictionary, currentLanguage, locKey, number ) }
-    </span>
+    return React.DOM.text({}, translate( dictionary, currentLanguage, locKey, number ));
 }
 
 export default Loc


### PR DESCRIPTION
Span tag problem.
Example:
```
<select>
<option><Loc lockey="hello"></option>
</select>
```
transforms to 
```
<select>
<option><span>Hola</span></option>
</select>
```
but should to 
```
<select>
<option>Hola</option>
</select>
```