### PR TITLE
Provide props from <Loc/> to inner <span/>

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-    "presets": ["es2015", "react"]
+    "presets": ["es2015", "react"],
+    "plugins": ["transform-object-rest-spread"]
 }

--- a/example/src/components/Texts.js
+++ b/example/src/components/Texts.js
@@ -12,7 +12,7 @@ const Texts = ({ count }) => {
                     <h3><Loc locKey="key_1"/></h3>
                 </p>
                 <p>
-                    <h3 style={{color: "red"}}><Loc locKey="key_2" number={count}/></h3>
+                    <h3><Loc locKey="key_2" number={count} style={{color: "red"}}/></h3>
                 </p>
                 <p>
                     <h3><Loc locKey="key_3" number={count}/></h3>

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.0",
+    "babel-plugin-transform-object-rest-spread": "^6.22.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0"
   },

--- a/src/LocPresentational.js
+++ b/src/LocPresentational.js
@@ -1,8 +1,8 @@
 import translate from 'translatr'
 import React from 'react'
 
-const Loc = ({ currentLanguage, locKey, number, dictionary }) => {
-    return <span>
+const Loc = ( { currentLanguage, locKey, number, dictionary, dispatch, ...rest } ) => {
+    return <span { ...rest }>
         { translate( dictionary, currentLanguage, locKey, number ) }
     </span>
 }


### PR DESCRIPTION
This PR avoids redundant wrappers, by forwarding props (e.g. `style` or `className`) from `<Loc/>` to his child.
So we can apply it right on `<Loc/>`:

Before:
```js
<span style='color: red'><Loc locKey="PageTitle"/></span>
```

After:
```js
<Loc locKey="PageTitle" style='color: red'/>
```