### PR TITLE
babel-core was moved from devDependencies to dependencies section

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
@@ -47,7 +46,8 @@
     "react": ">=16.0.0"
   },
   "dependencies": {
-    "translatr": ">=2.1.0"
+    "translatr": ">=2.1.0",
+    "babel-core": "^6.26.0"
   },
   "jest": {
     "rootDir": "./tests",


### PR DESCRIPTION
redux-react-i18n require babel-runtime ( which is a dependency of babel-core package ). If you use redux-react-i18n in projects with babel 7( or greater ), and that projects doesn't have a babel-runtime dependency, you will get an error like "Can't find babel-runtime/*** ". You should move package babel-core to dependencies section instead using it in devDependencies. Once redux-react-i18n package is installed, all packages from dependencies section are also installed, not from devDependencies.